### PR TITLE
Retrieve coordinates from SharedPreferences.

### DIFF
--- a/app/src/main/kotlin/com/weatherApp/utils/PreferencesManager.kt
+++ b/app/src/main/kotlin/com/weatherApp/utils/PreferencesManager.kt
@@ -11,17 +11,17 @@ class PreferencesManager(context: Context) {
     //TODO get sharedPreferences file
 
     //TODO save data in SharedPreferences
-    fun saveLocation(city: String, latitude: Double, longitude: Double) {
+    fun saveLocation(city: String, latitude: Double?, longitude: Double?) {
         if (sharedPreference.checkConnection().isSuccess){
             sharedPreference.sharedPrefs.edit{
                 putString("City",city)
-                putString("Latitud",latitude.toString())
-                putString("Longitude",longitude.toString())
+                putFloat("Latitud",latitude?.toFloat() ?: 0.0f)
+                putFloat("Longitude",longitude?.toFloat() ?: 0.0f)
             }
         }
     }
     //TODO implement getters for SharedPreferences values, using mock data by now
-    fun getCityName(): String? = "Ávila"
-    fun getLatitude(): Float? = 40.6572f
-    fun getLongitude(): Float? = -4.6995f
+    fun getCityName(): String? = sharedPreference.sharedPrefs.getString("City",null)
+    fun getLatitude(): Float? = sharedPreference.sharedPrefs.getFloat("Latitud",0.0f)
+    fun getLongitude(): Float? = sharedPreference.sharedPrefs.getFloat("Longitude",0.0f)
 }


### PR DESCRIPTION
## 🤔 Breve descripción del problema a resolver
Hacer que se puedan recuperar las coordenadas de SharedPreference.
## 💡 Proceso seguido para resolver el problema.
Se modificaron los getters que había en el PreferencesManager.kt, y se modificaron en la función de saveLocation para que s epueda introducir nulos. 
## 👩‍💻 Resumen técnico de la Solución
1. Se modificaron los getters de PreferencesManager.kt
2. Se modificaron los parámetros de saveLocation de la clase PreferencesManager.kt, para que se puedan introducir nulos

## 📸 Screenshot o Video
<img width="329" height="756" alt="image" src="https://github.com/user-attachments/assets/6e529954-de9f-44ac-acfb-837d7b40fe5a" />

## 🌈 Añade un Gif que represente a esta PR
![giphy](https://github.com/user-attachments/assets/8423657e-558c-4c73-b97e-f0e17eded608)

## ✅ Checklist
- [x] La rama tiene el formato correcto: tipo_de_issue/numero_issue/descripcion.
- [x] He añadido un título a la PR descriptivo.
- [x] Me he asignado como autor.
- [x] He relacionado la PR con la Issue.
